### PR TITLE
flatpak: Add the debug environment to finish-args

### DIFF
--- a/org.p2panda.aardvark.json
+++ b/org.p2panda.aardvark.json
@@ -12,17 +12,15 @@
         "--share=ipc",
         "--socket=fallback-x11",
         "--device=dri",
-        "--socket=wayland"
+        "--socket=wayland",
+        "--env=RUST_BACKTRACE=1",
+        "--env=RUST_LOG=aardvark=debug"
     ],
     "build-options" : {
         "append-path" : "/usr/lib/sdk/rust-stable/bin",
         "build-args" : [
             "--share=network"
-        ],
-        "env" : {
-            "RUST_BACKTRACE" : "1",
-            "RUST_LOG" : "aardvark=debug"
-        }
+        ]
     },
     "cleanup" : [
         "/include",


### PR DESCRIPTION
Instead of the build context. The build context really is only about building the app, while finish-args is about running it.