### PR TITLE
node: Wrap the network code into a struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,7 @@ dependencies = [
  "serde",
  "tokio",
  "tokio-stream",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,7 @@ dependencies = [
  "gettext-rs",
  "gtk4",
  "libadwaita",
+ "p2panda-core",
  "serde",
  "serde_json",
  "sourceview5",

--- a/aardvark-app/Cargo.toml
+++ b/aardvark-app/Cargo.toml
@@ -14,6 +14,7 @@ serde_json = "1.0.128"
 tokio = { version = "1.42.0", features = ["full"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 sourceview = { package = "sourceview5", version = "0.9" }
+p2panda-core = { version = "0.2.0", default-features = false }
 
 [dependencies.adw]
 package = "libadwaita"

--- a/aardvark-app/src/application.rs
+++ b/aardvark-app/src/application.rs
@@ -25,6 +25,7 @@ use adw::prelude::*;
 use adw::subclass::prelude::*;
 use gettextrs::gettext;
 use gtk::{gio, glib};
+use p2panda_core::PrivateKey;
 use tokio::sync::{mpsc, oneshot};
 use automerge::PatchAction;
 
@@ -57,7 +58,10 @@ mod imp {
 
         fn new() -> Self {
             let document = Document::default();
-            let (backend_shutdown, tx, rx) = network::run().expect("running p2p backend");
+            let private_key = PrivateKey::new();
+            let public_key = private_key.public_key();
+
+            let (backend_shutdown, tx, rx) = network::run(private_key).expect("running p2p backend");
 
             AardvarkApplication {
                 document,

--- a/aardvark-node/Cargo.toml
+++ b/aardvark-node/Cargo.toml
@@ -16,3 +16,4 @@ p2panda-sync = { version = "0.2.0", features = ["log-sync"] }
 serde = { version = "1.0.215", features = ["derive"] }
 tokio = { version = "1.42.0", features = ["full"] }
 tokio-stream = "0.1.17"
+tracing = "0.1"

--- a/aardvark-node/src/network.rs
+++ b/aardvark-node/src/network.rs
@@ -10,17 +10,17 @@ use p2panda_net::config::GossipConfig;
 use p2panda_net::{FromNetwork, NetworkBuilder, SyncConfiguration, ToNetwork, TopicId};
 use p2panda_store::MemoryStore;
 use p2panda_stream::{DecodeExt, IngestExt};
-use p2panda_sync::log_sync::{LogSyncProtocol, TopicLogMap};
 use p2panda_sync::TopicQuery;
+use p2panda_sync::log_sync::{LogSyncProtocol, TopicLogMap};
 use serde::{Deserialize, Serialize};
 use tokio::runtime::Builder;
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
-use tokio_stream::wrappers::ReceiverStream;
 use tokio_stream::StreamExt;
+use tokio_stream::wrappers::ReceiverStream;
 
 use crate::operation::{
-    create_operation, decode_gossip_message, encode_gossip_operation, AardvarkExtensions,
+    AardvarkExtensions, create_operation, decode_gossip_message, encode_gossip_operation,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq, StdHash, Serialize, Deserialize)]

--- a/aardvark-node/src/network.rs
+++ b/aardvark-node/src/network.rs
@@ -167,6 +167,13 @@ impl Network {
         });
     }
 
+    pub fn shutdown(&self) {
+        let network = self.inner.network.get().expect("network running").clone();
+        self.inner.runtime.block_on(async move {
+            network.shutdown().await.expect("network to shutdown");
+        });
+    }
+
     pub fn get_or_create_document(
         &self,
         document_id: Hash,

--- a/aardvark-node/src/network.rs
+++ b/aardvark-node/src/network.rs
@@ -80,7 +80,9 @@ impl TopicLogMap<TextDocument, LogId> for TextDocumentStore {
 }
 
 #[allow(clippy::type_complexity)]
-pub fn run() -> Result<(
+pub fn run(
+    private_key: PrivateKey,
+) -> Result<(
     oneshot::Sender<()>,
     mpsc::Sender<Vec<u8>>,
     mpsc::Receiver<Vec<u8>>,
@@ -99,9 +101,6 @@ pub fn run() -> Result<(
         runtime.block_on(async move {
             let network_id = Hash::new(b"aardvark <3");
             let document_id = TextDocument(Hash::new(b"my first doc <3").into());
-
-            let private_key = PrivateKey::new();
-            println!("my public key: {}", private_key.public_key());
 
             let mut operations_store = MemoryStore::<LogId, AardvarkExtensions>::new();
             let documents_store = TextDocumentStore::new();

--- a/aardvark-node/src/network.rs
+++ b/aardvark-node/src/network.rs
@@ -13,7 +13,8 @@ use p2panda_stream::{DecodeExt, IngestExt};
 use p2panda_sync::TopicQuery;
 use p2panda_sync::log_sync::{LogSyncProtocol, TopicLogMap};
 use serde::{Deserialize, Serialize};
-use tokio::runtime::Builder;
+use tokio::runtime::{Builder, Runtime};
+use tokio::sync::OnceCell;
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
 use tokio_stream::StreamExt;
@@ -79,65 +80,122 @@ impl TopicLogMap<TextDocument, LogId> for TextDocumentStore {
     }
 }
 
-#[allow(clippy::type_complexity)]
-pub fn run(
-    private_key: PrivateKey,
-) -> Result<(
-    oneshot::Sender<()>,
-    mpsc::Sender<Vec<u8>>,
-    mpsc::Receiver<Vec<u8>>,
-)> {
-    let (to_network, mut from_app) = mpsc::channel::<Vec<u8>>(512);
-    let (to_app, from_network) = mpsc::channel(512);
+pub struct Network {
+    inner: Arc<NetworkInner>,
+}
 
-    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+struct NetworkInner {
+    runtime: Runtime,
+    #[allow(dead_code)]
+    shutdown_tx: OnceCell<oneshot::Sender<()>>,
+    operations_store: MemoryStore<LogId, AardvarkExtensions>,
+    documents_store: TextDocumentStore,
+    network: OnceCell<p2panda_net::Network<TextDocument>>,
+    private_key: OnceCell<PrivateKey>,
+}
 
-    std::thread::spawn(move || {
+impl Default for Network {
+    fn default() -> Self {
+        Network::new()
+    }
+}
+
+impl Network {
+    pub fn new() -> Self {
+        let operations_store = MemoryStore::<LogId, AardvarkExtensions>::new();
+        let documents_store = TextDocumentStore::new();
+
         let runtime = Builder::new_current_thread()
             .enable_all()
             .build()
             .expect("backend runtime ready to spawn tasks");
 
-        runtime.block_on(async move {
-            let network_id = Hash::new(b"aardvark <3");
-            let document_id = TextDocument(Hash::new(b"my first doc <3").into());
+        Network {
+            inner: Arc::new(NetworkInner {
+                operations_store,
+                documents_store,
+                network: OnceCell::new(),
+                private_key: OnceCell::new(),
+                shutdown_tx: OnceCell::new(),
+                runtime,
+            }),
+        }
+    }
 
-            let mut operations_store = MemoryStore::<LogId, AardvarkExtensions>::new();
-            let documents_store = TextDocumentStore::new();
-            documents_store
-                .write()
-                .authors
-                .insert(private_key.public_key(), vec![document_id.clone()]);
+    pub fn run(&self, private_key: PrivateKey, network_id: Hash) {
+        let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+        let sync = LogSyncProtocol::new(
+            self.inner.documents_store.clone(),
+            self.inner.operations_store.clone(),
+        );
+        let sync_config = SyncConfiguration::<TextDocument>::new(sync);
 
-            let sync = LogSyncProtocol::new(documents_store.clone(), operations_store.clone());
-            let sync_config = SyncConfiguration::<TextDocument>::new(sync);
+        self.inner
+            .private_key
+            .set(private_key.clone())
+            .expect("network can be run only once");
 
-            let network = NetworkBuilder::new(network_id.into())
-                .private_key(private_key.clone())
-                .discovery(LocalDiscovery::new())
-                .gossip(GossipConfig {
-                    // @TODO(adz): This is a temporary workaround to account for Automerge giving
-                    // us surprisingly fairly large payloads which break the default gossip message
-                    // size limit given by iroh-gossip (4092 bytes).
-                    //
-                    // This especially happens if another peer edits a document for the first time
-                    // which already contains some text, even if it's just adding one single
-                    // character. It's also surprising that the 4kb limit is reached even if the
-                    // text itself is less than ca. 100 characters long.
-                    //
-                    // I believe we can fix this by understanding better how Automerge's "diffs"
-                    // are made and possibily using more low-level methods of their library to
-                    // really only send the actual changed text.
-                    //
-                    // Related issue: https://github.com/p2panda/aardvark/issues/11
-                    max_message_size: 512_000,
-                    ..Default::default()
-                })
-                .sync(sync_config)
-                .build()
-                .await
-                .expect("network spawning");
+        self.inner
+            .shutdown_tx
+            .set(shutdown_tx)
+            .expect("network can be run only once");
 
+        let network_inner_clone = self.inner.clone();
+        std::thread::spawn(move || {
+            let network_inner_clone2 = network_inner_clone.clone();
+            network_inner_clone.runtime.block_on(async move {
+                network_inner_clone2
+                    .network
+                    .get_or_init(|| async {
+                        NetworkBuilder::new(network_id.into())
+                            .private_key(private_key)
+                            .discovery(LocalDiscovery::new())
+                            .gossip(GossipConfig {
+                                // @TODO(adz): This is a temporary workaround to account for Automerge giving
+                                // us surprisingly fairly large payloads which break the default gossip message
+                                // size limit given by iroh-gossip (4092 bytes).
+                                //
+                                // This especially happens if another peer edits a document for the first time
+                                // which already contains some text, even if it's just adding one single
+                                // character. It's also surprising that the 4kb limit is reached even if the
+                                // text itself is less than ca. 100 characters long.
+                                //
+                                // I believe we can fix this by understanding better how Automerge's "diffs"
+                                // are made and possibily using more low-level methods of their library to
+                                // really only send the actual changed text.
+                                //
+                                // Related issue: https://github.com/p2panda/aardvark/issues/11
+                                max_message_size: 512_000,
+                                ..Default::default()
+                            })
+                            .sync(sync_config)
+                            .build()
+                            .await
+                            .expect("network spawning")
+                    })
+                    .await;
+
+                shutdown_rx.await.unwrap();
+            });
+        });
+    }
+
+    pub fn get_or_create_document(
+        &self,
+        document_id: Hash,
+    ) -> (mpsc::Sender<Vec<u8>>, mpsc::Receiver<Vec<u8>>) {
+        let document_id = TextDocument(document_id.into());
+
+        let (to_network, mut from_app) = mpsc::channel::<Vec<u8>>(512);
+        let (to_app, from_network) = mpsc::channel(512);
+
+        let network_inner = self.inner.clone();
+        self.inner.runtime.spawn(async move {
+            // Wait for the network to be started
+            let network = network_inner
+                .network
+                .get_or_init(|| async { unreachable!("network not running") })
+                .await;
             let (topic_tx, topic_rx, ready) = network
                 .subscribe(document_id.clone())
                 .await
@@ -148,45 +206,42 @@ pub fn run(
                 println!("network joined!");
             });
 
-            // Task for handling operations arriving from the network.
-            let operations_store_clone = operations_store.clone();
             let document_id_clone = document_id.clone();
-            let _result: JoinHandle<Result<()>> = tokio::task::spawn(async move {
-                let stream = ReceiverStream::new(topic_rx);
+            let stream = ReceiverStream::new(topic_rx);
+            let stream = stream.filter_map(|event| match event {
+                FromNetwork::GossipMessage { bytes, .. } => match decode_gossip_message(&bytes) {
+                    Ok(result) => Some(result),
+                    Err(err) => {
+                        eprintln!("could not decode gossip message: {err}");
+                        None
+                    }
+                },
+                FromNetwork::SyncMessage {
+                    header, payload, ..
+                } => Some((header, payload)),
+            });
 
-                let stream = stream.filter_map(|event| match event {
-                    FromNetwork::GossipMessage { bytes, .. } => match decode_gossip_message(&bytes)
-                    {
-                        Ok(result) => Some(result),
-                        Err(err) => {
-                            eprintln!("could not decode gossip message: {err}");
-                            None
-                        }
-                    },
-                    FromNetwork::SyncMessage {
-                        header, payload, ..
-                    } => Some((header, payload)),
+            // Decode and ingest the p2panda operations.
+            let mut stream = stream
+                .decode()
+                .filter_map(|result| match result {
+                    Ok(operation) => Some(operation),
+                    Err(err) => {
+                        eprintln!("decode operation error: {err}");
+                        None
+                    }
+                })
+                .ingest(network_inner.operations_store.clone(), 128)
+                .filter_map(|result| match result {
+                    Ok(operation) => Some(operation),
+                    Err(err) => {
+                        eprintln!("ingest operation error: {err}");
+                        None
+                    }
                 });
 
-                // Decode and ingest the p2panda operations.
-                let mut stream = stream
-                    .decode()
-                    .filter_map(|result| match result {
-                        Ok(operation) => Some(operation),
-                        Err(err) => {
-                            eprintln!("decode operation error: {err}");
-                            None
-                        }
-                    })
-                    .ingest(operations_store_clone, 128)
-                    .filter_map(|result| match result {
-                        Ok(operation) => Some(operation),
-                        Err(err) => {
-                            eprintln!("ingest operation error: {err}");
-                            None
-                        }
-                    });
-
+            let documents_store = network_inner.documents_store.clone();
+            let _result: JoinHandle<Result<()>> = tokio::task::spawn(async move {
                 // Process the operations and forward application messages to app layer.
                 while let Some(operation) = stream.next().await {
                     let prune_flag: PruneFlag = operation.header.extract().unwrap_or_default();
@@ -225,6 +280,12 @@ pub fn run(
                 Ok(())
             });
 
+            let mut operations_store = network_inner.operations_store.clone();
+            let private_key = network_inner
+                .private_key
+                .get()
+                .expect("no private key set")
+                .clone();
             // Task for handling events coming from the application layer.
             let _result: JoinHandle<Result<()>> = tokio::task::spawn(async move {
                 while let Some(bytes) = from_app.recv().await {
@@ -260,10 +321,8 @@ pub fn run(
 
                 Ok(())
             });
-
-            shutdown_rx.await.unwrap();
         });
-    });
 
-    Ok((shutdown_tx, to_network, from_network))
+        (to_network, from_network)
+    }
 }


### PR DESCRIPTION
This takes the node relevant code out of https://github.com/p2panda/aardvark/pull/41