### PR TITLE
textbuffer: Only insert/delete changes from the CRDT document

### DIFF
--- a/aardvark-app/src/textbuffer.rs
+++ b/aardvark-app/src/textbuffer.rs
@@ -137,40 +137,40 @@ mod imp {
     impl TextBufferImpl for AardvarkTextBuffer {
         fn insert_text(&self, iter: &mut gtk::TextIter, new_text: &str) {
             let offset = iter.offset();
-            info!("inserting new text {} at pos {}", new_text, offset);
 
             if !self.inhibit_text_change.get() {
                 if let Some(document) = self.document.borrow().as_ref() {
-                    self.document_handlers.get().unwrap().block();
                     if let Err(error) = document.insert_text(offset, new_text) {
                         error!("Failed to submit changes to the document: {error}");
                     }
-                    self.document_handlers.get().unwrap().unblock();
                 }
-            }
+            } else {
+                // Only insert text received from the CRDT document
+                info!("inserting new text {} at pos {}", new_text, offset);
 
-            self.parent_insert_text(iter, new_text);
+                self.parent_insert_text(iter, new_text);
+            }
         }
 
         fn delete_range(&self, start: &mut gtk::TextIter, end: &mut gtk::TextIter) {
             let offset_start = start.offset();
             let offset_end = end.offset();
-            info!(
-                "deleting range at start {} end {}",
-                offset_start, offset_end
-            );
 
             if !self.inhibit_text_change.get() {
                 if let Some(document) = self.document.borrow().as_ref() {
-                    self.document_handlers.get().unwrap().block();
                     if let Err(error) = document.delete_range(offset_start, offset_end) {
                         error!("Failed to submit changes to the document: {error}")
                     }
-                    self.document_handlers.get().unwrap().unblock();
                 }
-            }
+            } else {
+                // Only delete text received from the CRDT document
+                info!(
+                    "deleting range at start {} end {}",
+                    offset_start, offset_end
+                );
 
-            self.parent_delete_range(start, end);
+                self.parent_delete_range(start, end);
+            }
         }
     }
 

--- a/aardvark-doc/src/document.rs
+++ b/aardvark-doc/src/document.rs
@@ -170,9 +170,17 @@ mod imp {
                                     break;
                                 }
                             }
-                            TextCrdtEvent::Local(_text_deltas) => {
-                                // TODO(adz): Later we want to apply changes to the text buffer
-                                // here.
+                            TextCrdtEvent::Local(text_deltas) => {
+                                for delta in text_deltas {
+                                    match delta {
+                                        TextDelta::Insert { index, chunk } => {
+                                            this.emit_text_inserted(index as i32, &chunk);
+                                        }
+                                        TextDelta::Remove { index, len } => {
+                                            this.emit_range_deleted(index as i32, (index + len) as i32);
+                                        }
+                                    }
+                                }
                             }
                             TextCrdtEvent::Remote(text_deltas) => {
                                 for delta in text_deltas {

--- a/aardvark-doc/src/document.rs
+++ b/aardvark-doc/src/document.rs
@@ -74,14 +74,14 @@ mod imp {
             }
         }
 
-        fn emit_text_inserted(&self, index: i32, text: &str) {
+        fn emit_text_inserted(&self, pos: i32, text: &str) {
             self.obj()
-                .emit_by_name::<()>("text-inserted", &[&index, &text]);
+                .emit_by_name::<()>("text-inserted", &[&pos, &text]);
         }
 
-        fn emit_range_deleted(&self, index: i32, length: i32) {
+        fn emit_range_deleted(&self, start: i32, end: i32) {
             self.obj()
-                .emit_by_name::<()>("range-deleted", &[&index, &length]);
+                .emit_by_name::<()>("range-deleted", &[&start, &end]);
         }
     }
 
@@ -181,7 +181,7 @@ mod imp {
                                             this.emit_text_inserted(index as i32, &chunk);
                                         }
                                         TextDelta::Remove { index, len } => {
-                                            this.emit_range_deleted(index as i32, len as i32);
+                                            this.emit_range_deleted(index as i32, (index + len) as i32);
                                         }
                                     }
                                 }
@@ -209,7 +209,7 @@ impl Document {
         self.imp().splice_text(index, 0, chunk)
     }
 
-    pub fn delete_range(&self, index: i32, len: i32) -> Result<()> {
-        self.imp().splice_text(index, len, "")
+    pub fn delete_range(&self, index: i32, end: i32) -> Result<()> {
+        self.imp().splice_text(index, end - index, "")
     }
 }


### PR DESCRIPTION
Ensure that changes to the text buffer always go through the CRDT
document.

Closes: https://github.com/p2panda/aardvark/issues/57

Based on #60 